### PR TITLE
Typo fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new Toiine\Bundle\CouchbaseBundle\ToiineCouchbaseBundle(),
+        new Toiine\CouchbaseBundle\ToiineCouchbaseBundle(),
         // ...
     );
 }


### PR DESCRIPTION
Corrected the namespace for ToiineCouchbaseBundle in Installation instructions.
